### PR TITLE
Tweak algorithm to not abbreviate words less than three characters long

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -12,6 +12,6 @@ export IFS=$'\n\t ,.';
 
 while read line; do
     for word in $line; do
-       echo "${word:0:1}$(( ${#word} - 2 ))${word: -1}" 
+        ((${#word} > 2)) && echo "${word:0:1}$(( ${#word} - 2 ))${word: -1}" || echo ${word}
     done
 done | tr '\n' ' '


### PR DESCRIPTION
Words which are 1 or 2 characters long are 'abbreviated' into a 3 character abbreviation.  This patch skips abbreviating these short words.

### Example
`echo "I am Groot" | bash main.sh`
#### Before
`I-1I a0m G3t`
#### After
`I am G3t`
